### PR TITLE
Fixed several incorrect default ini_setting key_val_separators

### DIFF
--- a/manifests/journald.pp
+++ b/manifests/journald.pp
@@ -10,10 +10,11 @@ class systemd::journald {
   $systemd::journald_settings.each |$option, $value| {
     ini_setting {
       $option:
-        path    => '/etc/systemd/journald.conf',
-        section => 'Journal',
-        setting => $option,
-        notify  => Service['systemd-journald'],
+        path              => '/etc/systemd/journald.conf',
+        section           => 'Journal',
+        setting           => $option,
+        key_val_separator => '=',
+        notify            => Service['systemd-journald'],
     }
     if $value =~ Hash {
       Ini_setting[$option] {

--- a/manifests/logind.pp
+++ b/manifests/logind.pp
@@ -10,10 +10,11 @@ class systemd::logind {
   $systemd::logind_settings.each |$option, $value| {
     ini_setting {
       $option:
-        path    => '/etc/systemd/logind.conf',
-        section => 'Login',
-        setting => $option,
-        notify  => Service['systemd-logind'],
+        path              => '/etc/systemd/logind.conf',
+        section           => 'Login',
+        setting           => $option,
+        key_val_separator => '=',
+        notify            => Service['systemd-logind'],
     }
     if $value =~ Hash {
       Ini_setting[$option] {

--- a/manifests/oomd.pp
+++ b/manifests/oomd.pp
@@ -11,10 +11,11 @@ class systemd::oomd {
   $systemd::oomd_settings.each |$option, $value| {
     ini_setting {
       $option:
-        path    => '/etc/systemd/oomd.conf',
-        section => 'OOM',
-        setting => $option,
-        notify  => Service['systemd-oomd'],
+        path              => '/etc/systemd/oomd.conf',
+        section           => 'OOM',
+        setting           => $option,
+        key_val_separator => '=',
+        notify            => Service['systemd-oomd'],
     }
     if $value =~ Hash {
       Ini_setting[$option] {

--- a/manifests/service_manager.pp
+++ b/manifests/service_manager.pp
@@ -52,11 +52,12 @@ class systemd::service_manager (
     }
 
     ini_setting { "system/${option}":
-      ensure  => $vh.get('ensure', 'present'),
-      path    => '/etc/systemd/system.conf',
-      section => 'Manager',
-      setting => $option,
-      value   => $vh['value'],
+      ensure            => $vh.get('ensure', 'present'),
+      path              => '/etc/systemd/system.conf',
+      section           => 'Manager',
+      setting           => $option,
+      value             => $vh['value'],
+      key_val_separator => '=',
     }
   }
 

--- a/manifests/timesyncd.pp
+++ b/manifests/timesyncd.pp
@@ -38,12 +38,13 @@ class systemd::timesyncd (
       $_ntp_server = join($ntp_server, ' ')
     }
     ini_setting { 'ntp_server':
-      ensure  => 'present',
-      value   => $_ntp_server,
-      setting => 'NTP',
-      section => 'Time',
-      path    => '/etc/systemd/timesyncd.conf',
-      notify  => Service['systemd-timesyncd'],
+      ensure            => 'present',
+      value             => $_ntp_server,
+      setting           => 'NTP',
+      section           => 'Time',
+      path              => '/etc/systemd/timesyncd.conf',
+      key_val_separator => '=',
+      notify            => Service['systemd-timesyncd'],
     }
   }
 


### PR DESCRIPTION
#### Pull Request (PR) description
The default key_val_separator for ini_setting is ' = ', however, in many of the files that are leveraging ini_setting having a space between the equals sign is incorrect and could actually cause the values to fail or be ignored entirely.

#### This Pull Request (PR) fixes the following issues
https://github.com/voxpupuli/puppet-systemd/issues/520
